### PR TITLE
出力先を /dist/finder に変更する

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
+[context.*.environment]
+  NODE_ENV="development"
+
 [context.master.environment]
   NODE_ENV="production"
-
-[context.dev.environment]
-  NODE_ENV="development"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[context.master.environment]
+  NODE_ENV="production"
+
+[context.dev.environment]
+  NODE_ENV="development"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,2 @@
-[context.*.environment]
-  NODE_ENV="development"
-
 [context.master.environment]
   NODE_ENV="production"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,0 @@
-[context.master.environment]
-  NODE_ENV="production"

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,4 @@
 module.exports = {
-  publicPath: process.env.NODE_ENV === 'production' ? '/finder/' : ''
+  publicPath: './',
+  outputDir: 'dist/finder/'
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  publicPath: '/finder/'
+  publicPath: process.env.NODE_ENV === 'production' ? '/finder/' : ''
 }


### PR DESCRIPTION
Netlify で publish directory を `dist` にし、ブラウザからは `/finder/` で表示させたい。そのため、 `vue.config.js` の `publicPath` と `outputDir` を編集した。
