### PR TITLE
デコモジPNGファイルをキャッシュ付きで配信するようにする

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/decomoji/*.png
+  Cache-Control: public, max-age=86400


### PR DESCRIPTION
5000以上のリクエストがあるので、キャッシュをもっと活用すると劇的に速くなると思いました。
304が返ってくるのがもったいなかったので。

Netlifyのドキュメントにあった `_headers` ファイルを使うやり方を試していますが、テストできていないので、プルリクしてから確認します。
https://docs.netlify.com/routing/headers/#syntax-for-the-headers-file