### PR TITLE
refactor: URLパラメータからコレクションを作る部分の改善

### DIFF
--- a/src/store/modules/decomoji/actions.ts
+++ b/src/store/modules/decomoji/actions.ts
@@ -54,36 +54,15 @@ export const actions: ActionTree<ThisState, RootState> = {
    */
   receive({ commit }, payload: ThisActionPayloads["receive"]) {
     // パラメータをパースしてコレクションに追加する
-    const { basic, extra, explicit, preview } = payload || {};
-    const _basic = isStringOfNotEmpty(basic)
-      ? basic
-          .split(",")
-          .map((name: string) => ({ name, category: "basic" as CategoryName }))
-      : [];
-    const _extra = isStringOfNotEmpty(extra)
-      ? extra
-          .split(",")
-          .map((name: string) => ({ name, category: "extra" as CategoryName }))
-      : [];
-    const _explicit = isStringOfNotEmpty(explicit)
-      ? explicit.split(",").map((name: string) => ({
-          name,
-          category: "explicit" as CategoryName
-        }))
-      : [];
-    const _preview = isStringOfNotEmpty(preview)
-      ? preview.split(",").map((name: string) => ({
-          name,
-          category: "preview" as CategoryName
-        }))
-      : [];
+    const parsedParams = payload || {};
 
-    commit(RECEIVE_COLLECTION, [
-      ..._basic,
-      ..._extra,
-      ..._explicit,
-      ..._preview
-    ]);
+    const collection = Object.entries(parsedParams).map(parsedParam => {
+      const [category, valueStr] = parsedParam;
+      const values = valueStr ? valueStr.split(",") : [];
+      return values.map(name => ({ name, category }));
+    }).flat();
+
+    commit(RECEIVE_COLLECTION, collection);
   },
 
   /**

--- a/src/store/modules/decomoji/actions.ts
+++ b/src/store/modules/decomoji/actions.ts
@@ -18,6 +18,7 @@ import {
 } from "./mutation-types";
 import { isStringOfNotEmpty } from "@/utilities/isString";
 import { ActionTree } from "vuex";
+import { Collection } from "@/models/Collection";
 
 export const actions: ActionTree<ThisState, RootState> = {
   /**
@@ -53,14 +54,17 @@ export const actions: ActionTree<ThisState, RootState> = {
    * @param payload
    */
   receive({ commit }, payload: ThisActionPayloads["receive"]) {
+    type IdentifiedArray = [CategoryName, string];
     // パラメータをパースしてコレクションに追加する
     const parsedParams = payload || {};
 
-    const collection = Object.entries(parsedParams).map(parsedParam => {
-      const [category, valueStr] = parsedParam;
-      const values = valueStr ? valueStr.split(",") : [];
-      return values.map(name => ({ name, category }));
-    }).flat();
+    const collection = (Object.entries(parsedParams) as IdentifiedArray[])
+      .map<Collection>((parsedParam: IdentifiedArray) => {
+        const [category, rest] = parsedParam;
+        const decomojis: string[] = rest ? rest.split(",") : [];
+        return decomojis.map(name => ({ name, category }));
+      })
+      .flat();
 
     commit(RECEIVE_COLLECTION, collection);
   },


### PR DESCRIPTION
パラメータをパースしてコレクションに追加する部分が、カテゴリの増減に対応できなかったので、カテゴリ名を知らなくても良い方法に変更しました。