### PR TITLE
layout shiftを軽減

### DIFF
--- a/src/assets/styles/components/_Decomoji.scss
+++ b/src/assets/styles/components/_Decomoji.scss
@@ -3,6 +3,7 @@
   border: 1px solid transparent;
   border-radius: 0.375rem;
   background-color: var(--bgDecomoji);
+  height: 130px;
   @include focusDecomoji;
 
   .-reacted .Main & {
@@ -31,12 +32,15 @@
     vertical-align: text-top;
 
     .-l & {
+      height: 64px;
       width: 64px;
     }
     .-m & {
+      height: 32px;
       width: 32px;
     }
     .-s & {
+      height: 16px;
       width: 16px;
     }
   }

--- a/src/components/DecomojiButton.vue
+++ b/src/components/DecomojiButton.vue
@@ -14,6 +14,7 @@
       :alt="nameShows ? '' : name"
       :src="`/decomoji/${category}/${name}.png`"
       class="__img"
+      height="64"
       width="64"
     />
     <span v-show="nameShows" :aria-label="name" class="__name">{{


### PR DESCRIPTION
layout shiftは「読み込みが進むと画面ががくっとするやつ」です。後続要素の位置計算をやり直すため実行時速度性能に影響が出ます。

- https://web.dev/cls/

この赤いやつ↓

![image](https://user-images.githubusercontent.com/355808/84473894-b2723380-ac3e-11ea-9d04-c06ffe08a5d8.png)
