### PR TITLE
[v3] virtual-scroll を導入する

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,0 @@
-{
-  "recommendations": [
-    "Vue.volar",
-    "Vue.vscode-typescript-vue-plugin",
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode"
-  ]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2470,8 +2470,8 @@
       }
     },
     "node_modules/decomoji": {
-      "version": "5.30.0",
-      "resolved": "git+ssh://git@github.com/decomoji/decomoji.git#5113ac9239c3309167b85cebc352b7b87475e8a4",
+      "version": "5.30.3",
+      "resolved": "git+ssh://git@github.com/decomoji/decomoji.git#bf6e87e63ac1672458b67d86feb77a60b4b55fc6",
       "license": "MIT"
     },
     "node_modules/deep-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.15.7",
       "hasInstallScript": true,
       "dependencies": {
+        "@tanstack/vue-virtual": "^3.1.3",
         "decomoji": "github:decomoji/decomoji",
         "vue": "^3.4.15"
       },
@@ -890,6 +891,30 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.7.2.tgz",
       "integrity": "sha512-RbhOOTCNoCrbfkRyoXODZp75MlpiHMgbE5MEBZAnnnLyQNgrigEj4p0lzsMDyc1zVsJDLrivB58tgg3emX0eEA==",
       "dev": true
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.1.3.tgz",
+      "integrity": "sha512-Y5B4EYyv1j9V8LzeAoOVeTg0LI7Fo5InYKgAjkY1Pu9GjtUwX/EKxNcU7ng3sKr99WEf+bPTcktAeybyMOYo+g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/vue-virtual": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/vue-virtual/-/vue-virtual-3.1.3.tgz",
+      "integrity": "sha512-OoRCSgp8Bc85Te3pg4OHFUukbWZeB25/O5rNd7MgMtrYIfJjNOaicZeJcvwqK6lDVTMpzohWUMVK/loqR1H8ig==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.1.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "vue": "^2.7.0 || ^3.0.0"
+      }
     },
     "node_modules/@tsconfig/node20": {
       "version": "20.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2470,8 +2470,8 @@
       }
     },
     "node_modules/decomoji": {
-      "version": "5.30.3",
-      "resolved": "git+ssh://git@github.com/decomoji/decomoji.git#bf6e87e63ac1672458b67d86feb77a60b4b55fc6",
+      "version": "5.30.4",
+      "resolved": "git+ssh://git@github.com/decomoji/decomoji.git#4dbe06ef4801d7024083180bfaf1b786019cae4a",
       "license": "MIT"
     },
     "node_modules/deep-is": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@tanstack/vue-virtual": "^3.1.3",
     "decomoji": "github:decomoji/decomoji",
     "vue": "^3.4.15"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, watch } from 'vue'
+import { useVirtualizer } from '@tanstack/vue-virtual'
 import DecomojiBasic from 'decomoji/configs/v5_basic.json'
 import DecomojiExtra from 'decomoji/configs/v5_extra.json'
 import DecomojiExplicit from 'decomoji/configs/v5_explicit.json'
-import { useVirtualizer } from '@tanstack/vue-virtual'
-
+import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, watch } from 'vue'
 import { isStringOfNotEmpty } from './utilities/isString'
+
 
 // なぜかわからないが $event.target には value が生えていないので無理やり型を通す
 interface InputEventTarget extends EventTarget {

--- a/src/App.vue
+++ b/src/App.vue
@@ -402,10 +402,10 @@ const rowVirtualizer = useVirtualizer({
 const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems())
 const totalSize = computed(() => rowVirtualizer.value.getTotalSize())
 
-let timer = 0
+const debounce = ref(0)
 const debouncedInputSearch = (value: string) => {
-  window.clearTimeout(timer)
-  timer = setTimeout(() => {
+  window.clearTimeout(debounce.value)
+  debounce.value = setTimeout(() => {
     state.search = value
   }, 300)
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -69,6 +69,35 @@ interface ValueBySizeParams {
   [key: SizeName]: number
 }
 
+const RowPaddingValue: ValueBySizeParams = {
+  ll: 10,
+  l: 8,
+  m: 5,
+  s: 3,
+};
+
+const RowGapValue: ValueBySizeParams = {
+  ll: 10,
+  l: 8,
+  m: 5,
+  s: 3,
+};
+
+const MinWidthValue: ValueBySizeParams = {
+  ll: 128,
+  l: 80,
+  m: 42,
+  s: 24,
+};
+
+const RowHeightValue: ValueBySizeParams = {
+  ll: 139,
+  l: 88,
+  m: 50,
+  s: 28,
+};
+
+
 // 全 デコモジアイテムに collected プロパティを追加する
 const availableDecomojis: DecomojiItem[] = [...DecomojiBasic].map((v) => ({
   ...v,

--- a/src/App.vue
+++ b/src/App.vue
@@ -699,14 +699,14 @@ onMounted(() => {
               <span aria-hidden="true">:</span>{{ name }}<span aria-hidden="true">:</span>
             </span>
             <span
-              v-if="state.size === 'll' && state.created"
-              class="absolute top-[-10px] left-[-3px] border border-solid border-[--borderDecomojiCollected] py-[2px] px-[5px] rounded-md text-[--colorTag] bg-[--bgTag]"
+              v-if="(state.size === 'll' || state.size === '') && state.created"
+              class="absolute top-[-8px] left-[-5px] border border-solid border-[--borderDecomojiCollected] py-[2px] px-[5px] rounded-md text-[--colorTag] bg-[--bgTag]"
             >
               <span class="sr-only">created:</span>{{ created }}
             </span>
             <span
-              v-if="state.size === 'll' && state.updated && updated"
-              class="absolute top-[-10px] right-[-3px] border border-solid border-[--borderDecomojiCollected] py-[2px] px-[5px] rounded-md text-[--colorTag] bg-[--bgTag]"
+              v-if="(state.size === 'll' || state.size === '') && state.updated && updated"
+              class="absolute top-[-8px] right-[-5px] border border-solid border-[--borderDecomojiCollected] py-[2px] px-[5px] rounded-md text-[--colorTag] bg-[--bgTag]"
             >
               <span class="sr-only">updated:</span>{{ updated }}</span
             >

--- a/src/App.vue
+++ b/src/App.vue
@@ -73,30 +73,29 @@ const RowPaddingValue: ValueBySizeParams = {
   ll: 10,
   l: 8,
   m: 5,
-  s: 3,
-};
+  s: 3
+}
 
 const RowGapValue: ValueBySizeParams = {
   ll: 10,
   l: 8,
   m: 5,
-  s: 3,
-};
+  s: 3
+}
 
 const MinWidthValue: ValueBySizeParams = {
   ll: 128,
   l: 80,
   m: 42,
-  s: 24,
-};
+  s: 24
+}
 
 const RowHeightValue: ValueBySizeParams = {
   ll: 139,
   l: 88,
   m: 50,
-  s: 28,
-};
-
+  s: 28
+}
 
 // 全 デコモジアイテムに collected プロパティを追加する
 // TODO: ...DecomojiExtra, を混ぜるとハングアップする
@@ -365,7 +364,7 @@ const rowVirtualizer = useVirtualizer({
   count: filtered.value.length / columnsLength.value,
   getScrollElement: () => parentRef.value,
   estimateSize: () => rowHeightBySize.value,
-  overscan: 5,
+  overscan: 5
 })
 
 const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems())
@@ -588,25 +587,21 @@ onBeforeMount(() => {
 
     <main ref="parentRef" class="overflow-auto">
       <h2 class="sr-only">デコモジ一覧</h2>
-      <div
-        class="relative w-full"
-        :style="{ height: `${totalSize}px`}"
-      >
+      <div class="relative w-full" :style="{ height: `${totalSize}px` }">
         <div
-          v-for="virtualRow in virtualRows"
-          :key="virtualRow.index"
-          :class="classBySize.wrapper"
+          v-for="{ size, start, index } in virtualRows"
+          :key="index"
+          :class="[
+            classBySize.wrapper,
+            'absolute top-0 left-0 w-full'
+          ]"
           :style="{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            height: `${virtualRow.size}px`,
-            transform: `translateY(${virtualRow.start}px)`,
+            height: `${size}px`,
+            transform: `translateY(${start}px)`
           }"
         >
           <button
-            v-for="{ name, path, collected, created, updated} in splitedFiltered(virtualRow.index)"
+            v-for="{ name, path, collected, created, updated } in splitedFiltered(index)"
             :key="name"
             :class="[
               classBySize.button,
@@ -667,9 +662,7 @@ onBeforeMount(() => {
           <button
             class="flex justify-center items-center w-8 h-8"
             title="コレクションをアルファベット順にソートする"
-            @click="
-              state.collected = state.collected.sort((a, b) => a.name.localeCompare(b.name))
-            "
+            @click="state.collected = state.collected.sort((a, b) => a.name.localeCompare(b.name))"
           >
             <span class="material-icons" aria-hidden="true">sort</span>
           </button>

--- a/src/App.vue
+++ b/src/App.vue
@@ -641,7 +641,13 @@ onMounted(() => {
 
     <main ref="parentRef">
       <h2 class="sr-only">デコモジ一覧</h2>
-      <div class="relative w-full" :style="{ marginTop: `${gapBySize}px`, height: `${Math.ceil(filtered.length / rowItemLength) * rowHeightBySize}px` }">
+      <div
+        class="relative w-full"
+        :style="{
+          marginTop: `${gapBySize}px`,
+          height: `${Math.ceil(filtered.length / rowItemLength) * rowHeightBySize}px`
+        }"
+      >
         <div
           v-for="{ size, start, index } in virtualRows"
           :key="index"

--- a/src/App.vue
+++ b/src/App.vue
@@ -585,72 +585,66 @@ onBeforeMount(() => {
       </div>
     </div>
 
-    <main>
+    <main ref="parentRef" class="overflow-auto">
       <h2 class="sr-only">デコモジ一覧</h2>
-      <!-- <div :class="classBySize.wrapper">
-      </div> -->
       <div
-        ref="parentRef"
-        class="overflow-auto"
+        class="relative w-full"
+        :style="{ height: `${totalSize}px`}"
       >
         <div
-          class="relative w-full"
-          :style="{ height: `${totalSize}px`}"
+          v-for="virtualRow in virtualRows"
+          :key="virtualRow.index"
+          :class="classBySize.wrapper"
+          :style="{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+            height: `${virtualRow.size}px`,
+            transform: `translateY(${virtualRow.start}px)`,
+          }"
         >
-          <div
-            v-for="virtualRow in virtualRows"
-            :key="virtualRow.index"
-            :class="classBySize.wrapper"
-            :style="{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              width: '100%',
-              height: `${virtualRow.size}px`,
-              transform: `translateY(${virtualRow.start}px)`,
-            }"
+          <button
+            v-for="{ name, path, collected, created, updated} in splitedFiltered(virtualRow.index)"
+            :key="name"
+            :class="[
+              classBySize.button,
+              {
+                'border-[--borderDecomojiReacted] bg-[--bgDecomojiReacted]':
+                  !collected && state.reacted,
+                'border-transparent bg-[--bgDecomoji]': !collected && !state.reacted,
+                'border-[--borderDecomojiCollected] bg-[--bgDecomojiCollected]': collected
+              }
+            ]"
+            @click="
+              collected
+                ? state.collected.splice(
+                    state.collected.findIndex((v) => v.name === name),
+                    1
+                  )
+                : state.collected.push({
+                    name: name,
+                    path: path
+                  })
+            "
           >
-            <button
-              :key="`main_${filtered[virtualRow.index].name}`"
-              :class="[
-                classBySize.button,
-                {
-                  'border-[--borderDecomojiReacted] bg-[--bgDecomojiReacted]':
-                    !filtered[virtualRow.index].collected && state.reacted,
-                  'border-transparent bg-[--bgDecomoji]': !filtered[virtualRow.index].collected && !state.reacted,
-                  'border-[--borderDecomojiCollected] bg-[--bgDecomojiCollected]': filtered[virtualRow.index].collected
-                }
-              ]"
-              @click="
-                filtered[virtualRow.index].collected
-                  ? state.collected.splice(
-                      state.collected.findIndex((v) => v.name === filtered[virtualRow.index].name),
-                      1
-                    )
-                  : state.collected.push({
-                      name: filtered[virtualRow.index].name,
-                      path: filtered[virtualRow.index].path
-                    })
-              "
+            <img :alt="name" :src="path" :class="classBySize.image" height="64" width="64" />
+            <span :class="classBySize.name">
+              <span aria-hidden="true">:</span>{{ name }}<span aria-hidden="true">:</span>
+            </span>
+            <span
+              v-if="state.size === 'll' && state.created"
+              class="absolute top-[-10px] left-[-3px] border border-solid border-[--borderDecomojiCollected] py-[2px] px-[5px] rounded-md text-[--colorTag] bg-[--bgTag]"
             >
-              <img :alt="filtered[virtualRow.index].name" :src="filtered[virtualRow.index].path" :class="classBySize.image" height="64" width="64" />
-              <span :class="classBySize.name">
-                <span aria-hidden="true">:</span>{{ filtered[virtualRow.index].name }}<span aria-hidden="true">:</span>
-              </span>
-              <span
-                v-if="state.size === 'll' && state.created"
-                class="absolute top-[-10px] left-[-3px] border border-solid border-[--borderDecomojiCollected] py-[2px] px-[5px] rounded-md text-[--colorTag] bg-[--bgTag]"
-              >
-                <span class="sr-only">created:</span>{{ filtered[virtualRow.index].created }}
-              </span>
-              <span
-                v-if="state.size === 'll' && state.updated && filtered[virtualRow.index].updated"
-                class="absolute top-[-10px] right-[-3px] border border-solid border-[--borderDecomojiCollected] py-[2px] px-[5px] rounded-md text-[--colorTag] bg-[--bgTag]"
-              >
-                <span class="sr-only">updated:</span>{{ filtered[virtualRow.index].updated }}</span
-              >
-            </button>
-          </div>
+              <span class="sr-only">created:</span>{{ created }}
+            </span>
+            <span
+              v-if="state.size === 'll' && state.updated && updated"
+              class="absolute top-[-10px] right-[-3px] border border-solid border-[--borderDecomojiCollected] py-[2px] px-[5px] rounded-md text-[--colorTag] bg-[--bgTag]"
+            >
+              <span class="sr-only">updated:</span>{{ updated }}</span
+            >
+          </button>
         </div>
       </div>
     </main>

--- a/src/App.vue
+++ b/src/App.vue
@@ -478,6 +478,11 @@ onBeforeMount(() => {
   state.reacted = reacted === 'true' ? true : false
   state.updated = updated === 'true' ? true : false
 })
+
+onMounted(() => {
+  window.addEventListener('resize', updateGridContainerSize)
+  updateGridContainerSize()
+})
 </script>
 
 <template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -776,7 +776,7 @@ onMounted(() => {
         このウェブアプリは
         <a
           href="https://twitter.com/otiext"
-          class="link:text-inherit visited:text-inherit hover:text-inherit active:text-inherit"
+          class="underline link:text-inherit visited:text-inherit hover:text-inherit active:text-inherit"
           >oti</a
         >
         が作りました。
@@ -784,7 +784,7 @@ onMounted(() => {
       <p class="ml-auto">
         <a
           href="https://github.com/decomoji/finder/"
-          class="link:text-inherit visited:text-inherit hover:text-inherit active:text-inherit"
+          class="underline link:text-inherit visited:text-inherit hover:text-inherit active:text-inherit"
           >GitHub</a
         >, MIT License.
       </p>

--- a/src/App.vue
+++ b/src/App.vue
@@ -430,7 +430,9 @@ watch(filtered, (newList, oldList) => {
 })
 
 // state を監視してURLにパラメータを追加する
-watch(state, () => window.history.replaceState({}, '', urlParams.value.length ? `?${urlParams.value}` : null))
+watch(state, () =>
+  window.history.replaceState(null, '', urlParams.value.length ? `?${urlParams.value}` : '/')
+)
 
 // URLパラメータから画面状態を復元する
 onBeforeMount(() => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -300,7 +300,7 @@ const downloadURL = computed(() => {
 
 // state.size に応じた CSS クラス名のセットを返す
 const classBySize = computed(() => {
-  let wrapper = 'grid grid-flow-row '
+  let wrapper = 'box-border grid grid-flow-row '
   let cWrapper = wrapper
   let button = 'box-border relative border border-solid rounded-md text-center '
   let cButton = button + 'border border-solid border-transparent bg-[--bgDecomojiCollected] '
@@ -309,31 +309,31 @@ const classBySize = computed(() => {
 
   switch (state.size) {
     case 'll':
-      wrapper += 'gap-3 grid-cols-[repeat(auto-fill,minmax(128px,1fr))] p-3'
+      wrapper += 'gap-3 grid-cols-[repeat(auto-fill,minmax(128px,1fr))] px-3'
       cWrapper += 'gap-3 grid-cols-[repeat(auto-fill,minmax(80px,1fr))] p-3'
-      button += 'h-[129px]'
+      button += 'h-[128px]'
       cButton += 'h-[80px]'
       image += 'w-[64px] h-[64px]'
       break
     case 'l':
-      wrapper += 'gap-2 grid-cols-[repeat(auto-fill,minmax(80px,1fr))] p-2'
-      cWrapper += wrapper
+      wrapper += 'gap-2 grid-cols-[repeat(auto-fill,minmax(80px,1fr))] px-2'
+      cWrapper += 'gap-2 grid-cols-[repeat(auto-fill,minmax(80px,1fr))] p-2'
       button += 'h-[80px]'
       cButton += button
       image += 'w-[64px] h-[64px]'
       name = 'sr-only'
       break
     case 'm':
-      wrapper += 'gap-1 grid-cols-[repeat(auto-fill,minmax(42px,1fr))] p-1'
-      cWrapper += wrapper
+      wrapper += 'gap-1 grid-cols-[repeat(auto-fill,minmax(42px,1fr))] px-1'
+      cWrapper += 'gap-1 grid-cols-[repeat(auto-fill,minmax(42px,1fr))] p-1'
       button += 'h-[45px]'
       cButton += button
       image += 'w-[32px] h-[32px]'
       name = 'sr-only'
       break
     case 's':
-      wrapper += 'gap-0.5 grid-cols-[repeat(auto-fill,minmax(24px,1fr))] p-0.5'
-      cWrapper += wrapper
+      wrapper += 'gap-0.5 grid-cols-[repeat(auto-fill,minmax(24px,1fr))] px-0.5'
+      cWrapper += 'gap-0.5 grid-cols-[repeat(auto-fill,minmax(24px,1fr))] p-0.5'
       button += 'h-[25px]'
       cButton += button
       image += 'w-[16px] h-[16px]'

--- a/src/App.vue
+++ b/src/App.vue
@@ -395,11 +395,9 @@ watch(filtered, (newList, oldList) => {
   }
   const headerHeight = parentRef.value.offsetTop // ということにする
 
-  const numOfRows = filtered.value.length / 8
+  const numOfRows = filtered.value.length / columnLength.value
   const listHeight = rowHeightBySize.value * numOfRows
   const maxScrollTop = headerHeight + listHeight - screenHeight // 下部paddingは省略
-
-  console.log(Math.min(el.scrollTop, maxScrollTop))
 
   el.scrollTop = Math.min(el.scrollTop, maxScrollTop)
 })

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeMount, reactive, watch, ref } from 'vue'
+import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, watch } from 'vue'
 import DecomojiBasic from 'decomoji/configs/v5_basic.json'
 import DecomojiExtra from 'decomoji/configs/v5_extra.json'
 import DecomojiExplicit from 'decomoji/configs/v5_explicit.json'
@@ -104,7 +104,11 @@ const RowHeightValue: ValueBySizeParams = {
 
 // 全 デコモジアイテムに collected プロパティを追加する
 // TODO: ...DecomojiExtra, を混ぜるとハングアップする
-const availableDecomojis: DecomojiItem[] = [...DecomojiBasic, ...DecomojiExplicit].map((v) => ({
+const availableDecomojis: DecomojiItem[] = [
+  ...DecomojiBasic,
+  // ...DecomojiExtra,
+  ...DecomojiExplicit
+].map((v) => ({
   ...v,
   collected: false
 }))
@@ -494,7 +498,7 @@ onMounted(() => {
       }
     ]"
   >
-    <div
+    <header
       class="sticky z-10 top-0 left-0 flex items-center gap-5 p-[--paddingHeader] w-full text-[--colorHeader] bg-[--bgHeader] shadow-[0_2px_4px_rgba(0,0,0,0.15),0_8px_8px_rgba(0,0,0,0.075)]"
     >
       <div class="flex items-center gap-[--betweenLogoSearch]">
@@ -650,7 +654,7 @@ onMounted(() => {
           </div>
         </details>
       </div>
-    </div>
+    </header>
 
     <main ref="parentRef" class="overflow-auto">
       <h2 class="sr-only">デコモジ一覧</h2>
@@ -658,7 +662,7 @@ onMounted(() => {
         <div
           v-for="{ size, start, index } in virtualRows"
           :key="index"
-          :class="[classBySize.wrapper, 'absolute top-0 left-0 w-full']"
+          :class="['absolute top-0 left-0 w-full', classBySize.wrapper]"
           :style="{
             height: `${size}px`,
             transform: `translateY(${start}px)`

--- a/src/App.vue
+++ b/src/App.vue
@@ -385,7 +385,7 @@ const rowDecomojis = (index: number) => {
   return filtered.value.slice(start, end)
 }
 
-const updateGridContainerSize = () => {
+const updateContainerWidth = () => {
   nextTick().then(() => {
     if (!(parentRef.value instanceof HTMLElement)) {
       throw new Error('Component must be rendered as an HTMLElement')
@@ -484,8 +484,8 @@ onBeforeMount(() => {
 })
 
 onMounted(() => {
-  window.addEventListener('resize', updateGridContainerSize)
-  updateGridContainerSize()
+  window.addEventListener('resize', updateContainerWidth)
+  updateContainerWidth()
 })
 </script>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -342,7 +342,7 @@ const classBySize = computed(() => {
 })
 
 // TODO: カラム数を動的に算出する必要がある
-const columnsLength = computed(() => {
+const columnLength = computed(() => {
   return 8
 })
 
@@ -361,7 +361,7 @@ const rowHeightBySize = computed(() => {
 const parentRef = ref<HTMLElement | null>(null)
 
 const rowVirtualizer = useVirtualizer({
-  count: filtered.value.length / columnsLength.value,
+  count: filtered.value.length / columnLength.value,
   getScrollElement: () => parentRef.value,
   estimateSize: () => rowHeightBySize.value,
   overscan: 5

--- a/src/App.vue
+++ b/src/App.vue
@@ -99,7 +99,8 @@ const RowHeightValue: ValueBySizeParams = {
 
 
 // 全 デコモジアイテムに collected プロパティを追加する
-const availableDecomojis: DecomojiItem[] = [...DecomojiBasic].map((v) => ({
+// TODO: ...DecomojiExtra, を混ぜるとハングアップする
+const availableDecomojis: DecomojiItem[] = [...DecomojiBasic,  ...DecomojiExplicit].map((v) => ({
   ...v,
   collected: false
 }))

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { computed, onBeforeMount, reactive, watch } from 'vue'
+import { computed, onBeforeMount, reactive, watch, type PropType, ref } from 'vue'
 import DecomojiBasic from 'decomoji/configs/v5_basic.json'
 import DecomojiExtra from 'decomoji/configs/v5_extra.json'
 import DecomojiExplicit from 'decomoji/configs/v5_explicit.json'
+import { useVirtualizer } from '@tanstack/vue-virtual'
 
 import { isStringOfNotEmpty } from './utilities/isString'
 
@@ -307,6 +308,18 @@ const classBySize = computed(() => {
   }
 })
 
+const parentRef = ref<HTMLElement | null>(null)
+
+const rowVirtualizer = useVirtualizer({
+  count: filtered.value.length,
+  getScrollElement: () => parentRef.value,
+  estimateSize: () => 129,
+  overscan: 5,
+})
+
+const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems())
+const totalSize = computed(() => rowVirtualizer.value.getTotalSize())
+
 // state を監視してURLにパラメータを追加する
 watch(state, () => window.history.replaceState({}, '', '?' + urlParams.value))
 
@@ -524,45 +537,71 @@ onBeforeMount(() => {
 
     <main>
       <h2 class="sr-only">デコモジ一覧</h2>
-      <div :class="classBySize.wrapper">
-        <button
-          v-for="{ name, path, created, updated, collected } in filtered"
-          :key="`main_${name}`"
-          :class="[
-            classBySize.button,
-            {
-              'border-[--borderDecomojiReacted] bg-[--bgDecomojiReacted]':
-                !collected && state.reacted,
-              'border-transparent bg-[--bgDecomoji]': !collected && !state.reacted,
-              'border-[--borderDecomojiCollected] bg-[--bgDecomojiCollected]': collected
-            }
-          ]"
-          @click="
-            collected
-              ? state.collected.splice(
-                  state.collected.findIndex((v) => v.name === name),
-                  1
-                )
-              : state.collected.push({ name, path })
-          "
+      <!-- <div :class="classBySize.wrapper">
+      </div> -->
+      <div
+        ref="parentRef"
+        class="overflow-auto"
+      >
+        <div
+          class="relative w-full"
+          :style="{ height: `${totalSize}px`}"
         >
-          <img :alt="name" :src="path" :class="classBySize.image" height="64" width="64" />
-          <span :class="classBySize.name">
-            <span aria-hidden="true">:</span>{{ name }}<span aria-hidden="true">:</span>
-          </span>
-          <span
-            v-if="state.size === 'll' && state.created"
-            class="absolute top-[-10px] left-[-3px] border border-solid border-[--borderDecomojiCollected] py-[2px] px-[5px] rounded-md text-[--colorTag] bg-[--bgTag]"
+          <div
+            v-for="virtualRow in virtualRows"
+            :key="virtualRow.index"
+            :class="classBySize.wrapper"
+            :style="{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              height: `${virtualRow.size}px`,
+              transform: `translateY(${virtualRow.start}px)`,
+            }"
           >
-            <span class="sr-only">created:</span>{{ created }}
-          </span>
-          <span
-            v-if="state.size === 'll' && state.updated && updated"
-            class="absolute top-[-10px] right-[-3px] border border-solid border-[--borderDecomojiCollected] py-[2px] px-[5px] rounded-md text-[--colorTag] bg-[--bgTag]"
-          >
-            <span class="sr-only">updated:</span>{{ updated }}</span
-          >
-        </button>
+            <button
+              :key="`main_${filtered[virtualRow.index].name}`"
+              :class="[
+                classBySize.button,
+                {
+                  'border-[--borderDecomojiReacted] bg-[--bgDecomojiReacted]':
+                    !filtered[virtualRow.index].collected && state.reacted,
+                  'border-transparent bg-[--bgDecomoji]': !filtered[virtualRow.index].collected && !state.reacted,
+                  'border-[--borderDecomojiCollected] bg-[--bgDecomojiCollected]': filtered[virtualRow.index].collected
+                }
+              ]"
+              @click="
+                filtered[virtualRow.index].collected
+                  ? state.collected.splice(
+                      state.collected.findIndex((v) => v.name === filtered[virtualRow.index].name),
+                      1
+                    )
+                  : state.collected.push({
+                      name: filtered[virtualRow.index].name,
+                      path: filtered[virtualRow.index].path
+                    })
+              "
+            >
+              <img :alt="filtered[virtualRow.index].name" :src="filtered[virtualRow.index].path" :class="classBySize.image" height="64" width="64" />
+              <span :class="classBySize.name">
+                <span aria-hidden="true">:</span>{{ filtered[virtualRow.index].name }}<span aria-hidden="true">:</span>
+              </span>
+              <span
+                v-if="state.size === 'll' && state.created"
+                class="absolute top-[-10px] left-[-3px] border border-solid border-[--borderDecomojiCollected] py-[2px] px-[5px] rounded-md text-[--colorTag] bg-[--bgTag]"
+              >
+                <span class="sr-only">created:</span>{{ filtered[virtualRow.index].created }}
+              </span>
+              <span
+                v-if="state.size === 'll' && state.updated && filtered[virtualRow.index].updated"
+                class="absolute top-[-10px] right-[-3px] border border-solid border-[--borderDecomojiCollected] py-[2px] px-[5px] rounded-md text-[--colorTag] bg-[--bgTag]"
+              >
+                <span class="sr-only">updated:</span>{{ filtered[virtualRow.index].updated }}</span
+              >
+            </button>
+          </div>
+        </div>
       </div>
     </main>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -368,6 +368,29 @@ const rowVirtualizer = useVirtualizer({
 const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems())
 const totalSize = computed(() => rowVirtualizer.value.getTotalSize())
 
+// 項目が減って虚無を表示していたらスクロール位置を戻す
+watch(filtered, (newList, oldList) => {
+  if (newList.length > oldList.length) {
+    return;
+  }
+
+  const el = document.documentElement;
+  const screenHeight = el.clientHeight;
+
+  if (!(parentRef.value instanceof HTMLElement)) {
+    throw new Error("Component must be rendered as an HTMLElement");
+  }
+  const headerHeight = parentRef.value.offsetTop; // ということにする
+
+  const numOfRows = filtered.value.length / 8;
+  const listHeight = rowHeightBySize.value * numOfRows;
+  const maxScrollTop = headerHeight + listHeight - screenHeight; // 下部paddingは省略
+
+  console.log(Math.min(el.scrollTop, maxScrollTop))
+
+  el.scrollTop = Math.min(el.scrollTop, maxScrollTop);
+})
+
 // state を監視してURLにパラメータを追加する
 watch(state, () => window.history.replaceState({}, '', '?' + urlParams.value))
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,7 @@ import { useVirtualizer } from '@tanstack/vue-virtual'
 
 import { isStringOfNotEmpty } from './utilities/isString'
 
-type SizeName = 's' | 'm' | 'l' | 'll'
+type SizeName = string | 's' | 'm' | 'l' | 'll'
 type CategoryName = string | 'basic' | 'extra' | 'explicit'
 type VersionName = string
 
@@ -63,6 +63,10 @@ interface State {
   size: SizeName
   updated: boolean
   version: VersionParams
+}
+
+interface ValueBySizeParams {
+  [key: SizeName]: number
 }
 
 // 全 デコモジアイテムに collected プロパティを追加する

--- a/src/App.vue
+++ b/src/App.vue
@@ -642,7 +642,7 @@ onMounted(() => {
       </div>
     </header>
 
-    <main ref="parentRef" class="overflow-auto">
+    <main ref="parentRef">
       <h2 class="sr-only">デコモジ一覧</h2>
       <div class="relative w-full" :style="{ height: `${totalSize}px` }">
         <div

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useWindowVirtualizer } from '@tanstack/vue-virtual'
 import DecomojiAll from 'decomoji/configs/v5_all.json'
+import DecomojiVersions from 'decomoji/configs/v5_versions.json'
 import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, watch } from 'vue'
 import { isStringOfNotEmpty } from './utilities/isString'
 
@@ -99,12 +100,7 @@ const createCategoryParams: (category: CategoryName[]) => CategoryParams = (cate
 }
 
 // created と updated を抽出してユニークなバージョンリストを作る
-const availableVersions = Array.from(
-  new Set([
-    ...availableDecomojis.map((v) => v.created),
-    ...availableDecomojis.flatMap((v) => (v.updated ? v.updated : []))
-  ])
-).sort((a, b) => a.localeCompare(b))
+const availableVersions: string[] = DecomojiVersions
 
 // { version_name: boolean } のオブジェクトを作る
 const createVersionParams: (version: VersionName[]) => VersionParams = (version) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -92,8 +92,8 @@ const RowItemWidthValue: ValueBySizeParams = {
 // TODO: ...DecomojiExtra, を混ぜるとハングアップする
 const availableDecomojis: DecomojiItem[] = [
   // ...DecomojiBasic,
+  // ...DecomojiExplicit,
   // ...DecomojiExtra,
-  // ...DecomojiExplicit
   ...DecomojiAll
 ]
 
@@ -179,7 +179,7 @@ const state: State = reactive({
   dark: false,
   reacted: false,
   search: '',
-  size: 'll',
+  size: '',
   updated: false,
   version: createVersionParams([])
 })
@@ -329,6 +329,12 @@ const classBySize = computed(() => {
       image += 'w-[16px] h-[16px]'
       name = 'sr-only'
       break
+    default:
+      wrapper += 'gap-3 grid-cols-[repeat(auto-fill,minmax(128px,1fr))] px-3'
+      cWrapper += 'gap-3 grid-cols-[repeat(auto-fill,minmax(80px,1fr))] p-3'
+      button += 'h-[128px]'
+      cButton += 'h-[80px]'
+      image += 'w-[64px] h-[64px]'
   }
   return {
     wrapper,

--- a/src/App.vue
+++ b/src/App.vue
@@ -251,11 +251,15 @@ const versionParam = computed(() => {
   return versions.length > 0 ? `version=${versions.join(',')}` : null
 })
 
+const searchRegex = computed(() => {
+  return RegExp(state.search)
+})
+
 // 各種表示条件に合わせてフィルターしたデコモジリストを返す
 const filtered = computed(() => {
   const matches = ({ name, category, created, updated }: MatchesParams) => {
     // デコモジの名前が検索クエリに含まれるか否か、または検索クエリが空であるか否か
-    const nameMatches = RegExp(state.search).test(name) || state.search === ''
+    const nameMatches = searchRegex.value.test(name) || state.search === ''
     // デコモジのカテゴリーが表示するカテゴリーであるか、または何も選択されていないか否か
     const categoryMatches = state.category[category] || categoryParam.value === null
     // デコモジの作成バージョンが、表示するバージョンであるか、または何も選択されていないか否か

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,7 +37,7 @@ interface DecomojiItem {
   path: string
   created: VersionName
   updated?: VersionName
-  collected: boolean
+  collected?: boolean
 }
 
 interface CollectedDecomojiItem
@@ -94,10 +94,7 @@ const availableDecomojis: DecomojiItem[] = [
   ...DecomojiBasic,
   // ...DecomojiExtra,
   ...DecomojiExplicit
-].map((v) => ({
-  ...v,
-  collected: false
-}))
+]
 
 // { category_name: boolean } の形を作る
 const createCategoryParams: (category: CategoryName[]) => CategoryParams = (category) => {

--- a/src/App.vue
+++ b/src/App.vue
@@ -390,7 +390,7 @@ const rowVirtualizer = useVirtualizer({
 })
 
 const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems())
-const totalSize = computed(() => rowVirtualizer.value.getTotalSize())
+// const totalSize = computed(() => rowVirtualizer.value.getTotalSize())
 
 const debounce = ref(0)
 const debouncedInputSearch = (value: string) => {
@@ -644,7 +644,7 @@ onMounted(() => {
 
     <main ref="parentRef">
       <h2 class="sr-only">デコモジ一覧</h2>
-      <div class="relative w-full" :style="{ height: `${totalSize}px` }">
+      <div class="relative w-full" :style="{ marginTop: `${gapBySize}px`, height: `${Math.ceil(filtered.length / rowItemLength) * rowHeightBySize}px` }">
         <div
           v-for="{ size, start, index } in virtualRows"
           :key="index"

--- a/src/App.vue
+++ b/src/App.vue
@@ -266,12 +266,14 @@ const filtered = computed(() => {
     return nameMatches && categoryMatches && (createdMatches || updatedMatches)
   }
 
-  return availableDecomojis
-    .filter((v: DecomojiItem) => matches(v))
-    .map((decomoji) => ({
-      ...decomoji,
-      collected: state.collected.find((v) => v.name === decomoji.name) ? true : false
-    }))
+  return availableDecomojis.flatMap((v: DecomojiItem) =>
+    matches(v)
+      ? {
+          ...v,
+          collected: state.collected.find((collcted) => collcted.name === v.name) ? true : undefined
+        }
+      : []
+  )
 })
 
 // コレクションを JSON 化した URL を返す

--- a/src/App.vue
+++ b/src/App.vue
@@ -346,13 +346,11 @@ const columnLength = computed(() => {
   return 8
 })
 
-const splitedFiltered = computed(() => {
-  return (index: number) => {
-    const start = columnsLength.value * index
-    const end = start + columnsLength.value
-    return filtered.value.slice(start, end)
-  }
-})
+const splitedFiltered = (index: number) => {
+  const start = 8 * index
+  const end = start + 8
+  return filtered.value.slice(start, end)
+}
 
 const rowHeightBySize = computed(() => {
   return RowHeightValue[state.size]

--- a/src/App.vue
+++ b/src/App.vue
@@ -381,6 +381,15 @@ const rowDecomojis = (index: number) => {
   return filtered.value.slice(start, end)
 }
 
+const updateGridContainerSize = () => {
+  nextTick().then(() => {
+    if (!(parentRef.value instanceof HTMLElement)) {
+      throw new Error('Component must be rendered as an HTMLElement')
+    }
+    containerWidth.value = parentRef.value.clientWidth
+  })
+}
+
 const parentRef = ref<HTMLElement | null>(null)
 
 const rowVirtualizer = useVirtualizer({

--- a/src/App.vue
+++ b/src/App.vue
@@ -288,19 +288,12 @@ const classBySize = computed(() => {
   let name = 'block mt-2.5 text-[--colorDecomoji] break-all'
 
   switch (state.size) {
-    case 'll':
-      wrapper += 'gap-3 grid-cols-[repeat(auto-fill,minmax(128px,1fr))] px-3'
-      cWrapper += 'gap-3 grid-cols-[repeat(auto-fill,minmax(80px,1fr))] p-3'
-      button += 'h-[128px]'
-      cButton += 'h-[80px]'
-      image += 'w-[64px] h-[64px]'
-      break
-    case 'l':
-      wrapper += 'gap-2 grid-cols-[repeat(auto-fill,minmax(80px,1fr))] px-2'
-      cWrapper += 'gap-2 grid-cols-[repeat(auto-fill,minmax(80px,1fr))] p-2'
-      button += 'h-[80px]'
+    case 's':
+      wrapper += 'gap-0.5 grid-cols-[repeat(auto-fill,minmax(24px,1fr))] px-0.5'
+      cWrapper += 'gap-0.5 grid-cols-[repeat(auto-fill,minmax(24px,1fr))] p-0.5'
+      button += 'h-[25px]'
       cButton += button
-      image += 'w-[64px] h-[64px]'
+      image += 'w-[16px] h-[16px]'
       name = 'sr-only'
       break
     case 'm':
@@ -311,20 +304,22 @@ const classBySize = computed(() => {
       image += 'w-[32px] h-[32px]'
       name = 'sr-only'
       break
-    case 's':
-      wrapper += 'gap-0.5 grid-cols-[repeat(auto-fill,minmax(24px,1fr))] px-0.5'
-      cWrapper += 'gap-0.5 grid-cols-[repeat(auto-fill,minmax(24px,1fr))] p-0.5'
-      button += 'h-[25px]'
+    case 'l':
+      wrapper += 'gap-2 grid-cols-[repeat(auto-fill,minmax(80px,1fr))] px-2'
+      cWrapper += 'gap-2 grid-cols-[repeat(auto-fill,minmax(80px,1fr))] p-2'
+      button += 'h-[80px]'
       cButton += button
-      image += 'w-[16px] h-[16px]'
+      image += 'w-[64px] h-[64px]'
       name = 'sr-only'
       break
+    case 'll':
     default:
       wrapper += 'gap-3 grid-cols-[repeat(auto-fill,minmax(128px,1fr))] px-3'
       cWrapper += 'gap-3 grid-cols-[repeat(auto-fill,minmax(80px,1fr))] p-3'
       button += 'h-[128px]'
       cButton += 'h-[80px]'
       image += 'w-[64px] h-[64px]'
+      break
   }
   return {
     wrapper,

--- a/src/App.vue
+++ b/src/App.vue
@@ -99,7 +99,7 @@ const RowHeightValue: ValueBySizeParams = {
 
 // 全 デコモジアイテムに collected プロパティを追加する
 // TODO: ...DecomojiExtra, を混ぜるとハングアップする
-const availableDecomojis: DecomojiItem[] = [...DecomojiBasic,  ...DecomojiExplicit].map((v) => ({
+const availableDecomojis: DecomojiItem[] = [...DecomojiBasic, ...DecomojiExplicit].map((v) => ({
   ...v,
   collected: false
 }))
@@ -362,7 +362,7 @@ const rowVirtualizer = useVirtualizer({
   count: filtered.value.length / columnLength.value,
   getScrollElement: () => parentRef.value,
   estimateSize: () => rowHeightBySize.value,
-  overscan: 5
+  overscan: 3
 })
 
 const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems())

--- a/src/App.vue
+++ b/src/App.vue
@@ -349,7 +349,10 @@ const classBySize = computed(() => {
 const containerWidth = ref(window.innerHeight)
 
 const columnLength = computed(() => {
-  return 8
+  const gridItemWidth = minWidthBySize.value + gapBySize.value
+  const gridContainerVirtualWidth =
+    containerWidth.value + gapBySize.value - rowPaddingBySize.value * 2
+  return Math.floor(gridContainerVirtualWidth / gridItemWidth)
 })
 
 // CSS Grid container の padding 値を返す

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,12 +1,8 @@
 <script setup lang="ts">
-import { useVirtualizer } from '@tanstack/vue-virtual';
-import DecomojiAll from 'decomoji/configs/v5_all.json';
-// import DecomojiBasic from 'decomoji/configs/v5_basic.json'
-// import DecomojiExplicit from 'decomoji/configs/v5_explicit.json'
-// import DecomojiExtra from 'decomoji/configs/v5_extra.json'
-import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, watch } from 'vue';
-import { isStringOfNotEmpty } from './utilities/isString';
 import { useWindowVirtualizer } from '@tanstack/vue-virtual'
+import DecomojiAll from 'decomoji/configs/v5_all.json'
+import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, watch } from 'vue'
+import { isStringOfNotEmpty } from './utilities/isString'
 
 // なぜかわからないが $event.target には value が生えていないので無理やり型を通す
 interface InputEventTarget extends EventTarget {
@@ -89,16 +85,9 @@ const RowItemWidthValue: ValueBySizeParams = {
   s: 24
 }
 
-// 全 デコモジアイテムに collected プロパティを追加する
-// TODO: ...DecomojiExtra, を混ぜるとハングアップする
-const availableDecomojis: DecomojiItem[] = [
-  // ...DecomojiBasic,
-  // ...DecomojiExplicit,
-  // ...DecomojiExtra,
-  ...DecomojiAll
-]
+const availableDecomojis: DecomojiItem[] = DecomojiAll
 
-// { category_name: boolean } の形を作る
+// { category_name: boolean } のオブジェクトを作る
 const createCategoryParams: (category: CategoryName[]) => CategoryParams = (category) => {
   return ['basic', 'extra', 'explicit'].reduce(
     (acc, name) => ({
@@ -117,7 +106,7 @@ const availableVersions = Array.from(
   ])
 ).sort((a, b) => a.localeCompare(b))
 
-// { version_name: boolean } の形を作る
+// { version_name: boolean } のオブジェクトを作る
 const createVersionParams: (version: VersionName[]) => VersionParams = (version) => {
   return availableVersions.reduce(
     (acc, name) => ({

--- a/src/App.vue
+++ b/src/App.vue
@@ -350,7 +350,7 @@ const classBySize = computed(() => {
   }
 })
 
-const containerWidth = ref(window.innerHeight)
+const containerWidth = ref(window.innerWidth)
 
 const columnLength = computed(() => {
   const gridItemWidth = minWidthBySize.value + gapBySize.value

--- a/src/App.vue
+++ b/src/App.vue
@@ -341,12 +341,29 @@ const classBySize = computed(() => {
   }
 })
 
+// TODO: カラム数を動的に算出する必要がある
+const columnsLength = computed(() => {
+  return 8
+})
+
+const splitedFiltered = computed(() => {
+  return (index: number) => {
+    const start = columnsLength.value * index
+    const end = start + columnsLength.value
+    return filtered.value.slice(start, end)
+  }
+})
+
+const rowHeightBySize = computed(() => {
+  return RowHeightValue[state.size]
+})
+
 const parentRef = ref<HTMLElement | null>(null)
 
 const rowVirtualizer = useVirtualizer({
-  count: filtered.value.length,
+  count: filtered.value.length / columnsLength.value,
   getScrollElement: () => parentRef.value,
-  estimateSize: () => 129,
+  estimateSize: () => rowHeightBySize.value,
   overscan: 5,
 })
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -386,7 +386,7 @@ const rowVirtualizer = useVirtualizer({
   count: Math.ceil(filtered.value.length / rowItemLength.value),
   getScrollElement: () => parentRef.value,
   estimateSize: () => rowHeightBySize.value,
-  overscan: 3
+  overscan: 0 // 0 出ないと余計な row が生成されてしまう
 })
 
 const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems())

--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,11 @@ import { useVirtualizer } from '@tanstack/vue-virtual'
 
 import { isStringOfNotEmpty } from './utilities/isString'
 
+// なぜかわからないが $event.target には value が生えていないので無理やり型を通す
+interface InputEventTarget extends EventTarget {
+  value: string
+}
+
 type SizeName = string | 's' | 'm' | 'l' | 'll'
 type CategoryName = string | 'basic' | 'extra' | 'explicit'
 type VersionName = string
@@ -368,6 +373,14 @@ const rowVirtualizer = useVirtualizer({
 const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems())
 const totalSize = computed(() => rowVirtualizer.value.getTotalSize())
 
+let timer = 0
+const debouncedInputSearch = (value: string) => {
+  window.clearTimeout(timer)
+  timer = setTimeout(() => {
+    state.search = value
+  }, 300)
+}
+
 // 項目が減って虚無を表示していたらスクロール位置を戻す
 watch(filtered, (newList, oldList) => {
   if (newList.length > oldList.length) {
@@ -460,11 +473,12 @@ onBeforeMount(() => {
         </h1>
         <div class="relative flex-[1_1_auto] text-[--shade-200] focus-within:text-[--shade-800]">
           <input
-            v-model="state.search"
+            :value="state.search"
             class="py-2.5 pl-[calc(1.5rem+var(--space-md))] pr-[calc(6.5rem+var(--space-md))] rounded-md w-full text-md bg-[rgba(255,255,255,0.25)] focus-within:bg-[rgba(255,255,255,0.95)]"
             type="text"
             name="search"
             title="検索"
+            @input="debouncedInputSearch(($event.target as InputEventTarget).value)"
           />
           <span
             class="material-icons pointer-events-none absolute top-[1px] bottom-0 left-2 m-auto w-6 h-6"

--- a/src/App.vue
+++ b/src/App.vue
@@ -393,7 +393,7 @@ const updateGridContainerSize = () => {
 const parentRef = ref<HTMLElement | null>(null)
 
 const rowVirtualizer = useVirtualizer({
-  count: filtered.value.length / columnLength.value,
+  count: Math.ceil(filtered.value.length / columnLength.value),
   getScrollElement: () => parentRef.value,
   estimateSize: () => rowHeightBySize.value,
   overscan: 3

--- a/src/App.vue
+++ b/src/App.vue
@@ -655,7 +655,7 @@ onMounted(() => {
           }"
         >
           <button
-            v-for="{ name, path, collected, created, updated } in rowDecomojis(index)"
+            v-for="{ name, path, collected, created, updated } in sliced(index)"
             :key="name"
             :class="[
               classBySize.button,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { useVirtualizer } from '@tanstack/vue-virtual'
+// import DecomojiAll from 'decomoji/configs/v5_all.json'
 import DecomojiBasic from 'decomoji/configs/v5_basic.json'
-import DecomojiExtra from 'decomoji/configs/v5_extra.json'
 import DecomojiExplicit from 'decomoji/configs/v5_explicit.json'
+// import DecomojiExtra from 'decomoji/configs/v5_extra.json'
 import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, watch } from 'vue'
 import { isStringOfNotEmpty } from './utilities/isString'
-
 
 // なぜかわからないが $event.target には value が生えていないので無理やり型を通す
 interface InputEventTarget extends EventTarget {

--- a/src/App.vue
+++ b/src/App.vue
@@ -375,6 +375,12 @@ const rowHeightBySize = computed(() => {
   return RowHeightValue[state.size || 'll']
 })
 
+const rowDecomojis = (index: number) => {
+  const start = columnLength.value * index
+  const end = start + columnLength.value
+  return filtered.value.slice(start, end)
+}
+
 const parentRef = ref<HTMLElement | null>(null)
 
 const rowVirtualizer = useVirtualizer({
@@ -645,7 +651,7 @@ onBeforeMount(() => {
           }"
         >
           <button
-            v-for="{ name, path, collected, created, updated } in splitedFiltered(index)"
+            v-for="{ name, path, collected, created, updated } in rowDecomojis(index)"
             :key="name"
             :class="[
               classBySize.button,

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onBeforeMount, reactive, watch, type PropType, ref } from 'vue'
+import { computed, onBeforeMount, reactive, watch, ref } from 'vue'
 import DecomojiBasic from 'decomoji/configs/v5_basic.json'
 import DecomojiExtra from 'decomoji/configs/v5_extra.json'
 import DecomojiExplicit from 'decomoji/configs/v5_explicit.json'
@@ -384,24 +384,24 @@ const debouncedInputSearch = (value: string) => {
 // 項目が減って虚無を表示していたらスクロール位置を戻す
 watch(filtered, (newList, oldList) => {
   if (newList.length > oldList.length) {
-    return;
+    return
   }
 
-  const el = document.documentElement;
-  const screenHeight = el.clientHeight;
+  const el = document.documentElement
+  const screenHeight = el.clientHeight
 
   if (!(parentRef.value instanceof HTMLElement)) {
-    throw new Error("Component must be rendered as an HTMLElement");
+    throw new Error('Component must be rendered as an HTMLElement')
   }
-  const headerHeight = parentRef.value.offsetTop; // ということにする
+  const headerHeight = parentRef.value.offsetTop // ということにする
 
-  const numOfRows = filtered.value.length / 8;
-  const listHeight = rowHeightBySize.value * numOfRows;
-  const maxScrollTop = headerHeight + listHeight - screenHeight; // 下部paddingは省略
+  const numOfRows = filtered.value.length / 8
+  const listHeight = rowHeightBySize.value * numOfRows
+  const maxScrollTop = headerHeight + listHeight - screenHeight // 下部paddingは省略
 
   console.log(Math.min(el.scrollTop, maxScrollTop))
 
-  el.scrollTop = Math.min(el.scrollTop, maxScrollTop);
+  el.scrollTop = Math.min(el.scrollTop, maxScrollTop)
 })
 
 // state を監視してURLにパラメータを追加する
@@ -626,10 +626,7 @@ onBeforeMount(() => {
         <div
           v-for="{ size, start, index } in virtualRows"
           :key="index"
-          :class="[
-            classBySize.wrapper,
-            'absolute top-0 left-0 w-full'
-          ]"
+          :class="[classBySize.wrapper, 'absolute top-0 left-0 w-full']"
           :style="{
             height: `${size}px`,
             transform: `translateY(${start}px)`

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import { useVirtualizer } from '@tanstack/vue-virtual'
-// import DecomojiAll from 'decomoji/configs/v5_all.json'
-import DecomojiBasic from 'decomoji/configs/v5_basic.json'
-import DecomojiExplicit from 'decomoji/configs/v5_explicit.json'
+import { useVirtualizer } from '@tanstack/vue-virtual';
+import DecomojiAll from 'decomoji/configs/v5_all.json';
+// import DecomojiBasic from 'decomoji/configs/v5_basic.json'
+// import DecomojiExplicit from 'decomoji/configs/v5_explicit.json'
 // import DecomojiExtra from 'decomoji/configs/v5_extra.json'
-import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, watch } from 'vue'
-import { isStringOfNotEmpty } from './utilities/isString'
+import { computed, nextTick, onBeforeMount, onMounted, reactive, ref, watch } from 'vue';
+import { isStringOfNotEmpty } from './utilities/isString';
 
 // なぜかわからないが $event.target には value が生えていないので無理やり型を通す
 interface InputEventTarget extends EventTarget {
@@ -91,9 +91,10 @@ const RowItemWidthValue: ValueBySizeParams = {
 // 全 デコモジアイテムに collected プロパティを追加する
 // TODO: ...DecomojiExtra, を混ぜるとハングアップする
 const availableDecomojis: DecomojiItem[] = [
-  ...DecomojiBasic,
+  // ...DecomojiBasic,
   // ...DecomojiExtra,
-  ...DecomojiExplicit
+  // ...DecomojiExplicit
+  ...DecomojiAll
 ]
 
 // { category_name: boolean } の形を作る
@@ -389,7 +390,7 @@ const rowVirtualizer = useVirtualizer({
   count: Math.ceil(filtered.value.length / rowItemLength.value),
   getScrollElement: () => parentRef.value,
   estimateSize: () => rowHeightBySize.value,
-  overscan: 0 // 0 出ないと余計な row が生成されてしまう
+  overscan: 0 // 0 でないと余計な row が生成されてしまう
 })
 
 const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems())

--- a/src/App.vue
+++ b/src/App.vue
@@ -346,7 +346,8 @@ const classBySize = computed(() => {
   }
 })
 
-// TODO: カラム数を動的に算出する必要がある
+const containerWidth = ref(window.innerHeight)
+
 const columnLength = computed(() => {
   return 8
 })

--- a/src/App.vue
+++ b/src/App.vue
@@ -352,14 +352,24 @@ const columnLength = computed(() => {
   return 8
 })
 
-const splitedFiltered = (index: number) => {
-  const start = 8 * index
-  const end = start + 8
-  return filtered.value.slice(start, end)
-}
+// CSS Grid container の padding 値を返す
+const rowPaddingBySize = computed(() => {
+  return RowPaddingValue[state.size || 'll']
+})
 
+// CSS Grid item の gap 値を返す
+const gapBySize = computed(() => {
+  return RowGapValue[state.size || 'll']
+})
+
+// CSS Grid item 幅の最小値を返す
+const minWidthBySize = computed(() => {
+  return MinWidthValue[state.size || 'll']
+})
+
+// 1行分の高さを返す
 const rowHeightBySize = computed(() => {
-  return RowHeightValue[state.size]
+  return RowHeightValue[state.size || 'll']
 })
 
 const parentRef = ref<HTMLElement | null>(null)


### PR DESCRIPTION
[TanStack Vertual](https://tanstack.com/virtual/latest) という Virtual Scroll プラグインを導入した。

当初は[サイズ固定のAPI](https://tanstack.com/virtual/latest/docs/framework/vue/examples/fixed)を使っていた。

デコモジファインダーでは横一列に収まる数がウィンドウ幅によって増減する。つまり Virtual Scroll させるアイテム数が動的に変わる。

これとサイズ固定のAPIとの相性が悪いようで、

- デコモジ表示サイズ変更で高さがおかしくなる
- 絞り込んで減っていくときはまぁまぁ見られるが、クエリを削除して全部表示に戻る時に耐えられない遅さになる
- ウィンドウサイズ変更でコンテナ高さが変わると Virtual Scroll 内容が更新されないことがある

など使用に堪えない体験になっていた。

パフォーマンスを計測して配列操作を高速化するなどしたがあまり改善せず。そこでふと[Dynamic](https://tanstack.com/virtual/latest/docs/framework/vue/examples/dynamic)というAPIを使用してみたところ、vue2 の頃と同等の操作パフォーマンスが出た。

もろもろ整えてハッピーな気持ちでPRを立てた次第。